### PR TITLE
Fixing entry point in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "engines": {
     "node": ">= 6"
   },
-  "main": "lib.js",
+  "main": "index.js",
   "scripts": {
     "clean": "shx rm -rf dist/ && shx mkdir -p dist",
     "reinstall": "shx rm -rf node_modules && npm install",


### PR DESCRIPTION
Since `lib.js` doesn't exist users are prevented from using this module on React Native as it doesn't recognize the `@feathersjs/client` import as being valid. 