### PR TITLE
Link client packages directly to builds and update all dependencies

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,5 @@ test/
 coverage/
 .github/
 browser/
+test/
+src/

--- a/authentication.js
+++ b/authentication.js
@@ -1,1 +1,1 @@
-module.exports = require('@feathersjs/authentication-client');
+module.exports = require('./dist/authentication');

--- a/core.js
+++ b/core.js
@@ -1,1 +1,1 @@
-module.exports = require('@feathersjs/feathers');
+module.exports = require('./dist/core');

--- a/index.js
+++ b/index.js
@@ -1,16 +1,1 @@
-const feathers = require('@feathersjs/feathers');
-const errors = require('@feathersjs/errors');
-const authentication = require('@feathersjs/authentication-client');
-const rest = require('@feathersjs/rest-client');
-const socketio = require('@feathersjs/socketio-client');
-const primus = require('@feathersjs/primus-client');
-
-Object.assign(feathers, {
-  errors,
-  authentication,
-  socketio,
-  primus,
-  rest
-});
-
-module.exports = feathers;
+module.exports = require('./dist/feathers');

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@feathersjs/authentication-client": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@feathersjs/authentication-client/-/authentication-client-1.0.0.tgz",
-      "integrity": "sha512-WbjtXkmFc+XtFE008rfu107o52LpWoqiDlmiYfm64axPf2qKlQTO/2CL69jr+j6MdRr7BEvck3rXqRwzIndIVg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/authentication-client/-/authentication-client-1.0.1.tgz",
+      "integrity": "sha512-KnZQ4BrA3tyFv0vryIBbcDuzLvpkoAKXKwFWbaKosUIYOsgflrsrGRnkhNYSfzNVw21RZ/mVRVOC2OtctB6fFQ==",
       "requires": {
         "@feathersjs/errors": "3.0.0",
         "debug": "3.1.0",
@@ -28,9 +28,9 @@
       }
     },
     "@feathersjs/express": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@feathersjs/express/-/express-1.0.0.tgz",
-      "integrity": "sha512-acuc6vfu3bsXqXot4wh9cekjnuwWBeCm9j9N92bS0xvxyfwO2Qq22kkcWhk1KXdLk+Rjzu66c6L7zv5RztYVDQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@feathersjs/express/-/express-1.1.2.tgz",
+      "integrity": "sha512-oxXZs3QAZB80fBajb7nh3Pbongm8ESXVnJw1EuX7fui4JOXh2qGw9hf8e3xKAZ/fmkHmgofdA1A3iqIzBg3Isw==",
       "dev": true,
       "requires": {
         "@feathersjs/commons": "1.2.0",
@@ -41,9 +41,9 @@
       }
     },
     "@feathersjs/feathers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-3.0.0.tgz",
-      "integrity": "sha512-SHrWPqCxKueca0MvvwYUtUkKR5X6oVK/3Opplx6oKD9ft6rr3KgX5buk49C/gcvTgMFxy8OX7Apzefw3ELkFiQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-3.0.1.tgz",
+      "integrity": "sha512-uRvzpnpwdW31+hQ67sGPQAQm09hmZrw1nc5om9yoSTouszjREcM2qusJkyWXN67/8Uythge6OjlYIP0NFJHVaw==",
       "requires": {
         "@feathersjs/commons": "1.2.0",
         "debug": "3.1.0",
@@ -52,30 +52,29 @@
       }
     },
     "@feathersjs/primus": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@feathersjs/primus/-/primus-3.0.0.tgz",
-      "integrity": "sha512-GW5/ziSWqfVygly1naTOHi5BwkrFWg6kgsFAFLhYnVJ76hQav+1H/rL7TTrQo+GNmfYXM8tl0nNedQDjrSb+BA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/primus/-/primus-3.0.1.tgz",
+      "integrity": "sha512-d9UilKqUSrHf0pKxXVf6NG5lXihwaJDQqUSMWnsf1ahkAYx2jAm8PtoyxXpHEEK13I2CvY1AB8JmRoCy7Rx6Cg==",
       "dev": true,
       "requires": {
-        "@feathersjs/socket-commons": "3.0.0",
+        "@feathersjs/socket-commons": "3.0.1",
         "debug": "3.1.0",
         "primus": "7.1.0",
         "primus-emitter": "3.1.1"
       }
     },
     "@feathersjs/primus-client": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@feathersjs/primus-client/-/primus-client-1.0.0.tgz",
-      "integrity": "sha512-v2kaLaFJNSPoiN+yxbgItqMHAVPvz0bJxY+eVADFipgRYiGGpDz3kKCvc7x8hSrCOFI7v1YcKv7JN7iM1F2qMQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/primus-client/-/primus-client-1.0.1.tgz",
+      "integrity": "sha512-Mw5/Az952m+n03cTrQoAwuOXDVtJCzGq7G8ZiIzj9ZE7V9tcv/hL/worwBKXgcXPT3cNhbUAisNVBEiJtdhTPg==",
       "requires": {
-        "@feathersjs/socket-commons": "3.0.0",
-        "ws": "3.2.0"
+        "@feathersjs/socket-commons": "3.0.1"
       }
     },
     "@feathersjs/rest-client": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@feathersjs/rest-client/-/rest-client-1.3.0.tgz",
-      "integrity": "sha512-a+yXcCiVo95AMFhLHpVphA0TZSLtsNGC9FGrq8+cWLp0z/b39l2eITELppnKeQFbMUB9Y0EU6PdFyE6DgliPgQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@feathersjs/rest-client/-/rest-client-1.3.2.tgz",
+      "integrity": "sha512-1gWzXqUOQWo2cyTRwu1ZdetKlG6TiaDlaDwv+MZ+i/UCn3IxqzL9gpZd76wiisOszBKgcb1+TFsVN3Vm218f0w==",
       "requires": {
         "@feathersjs/commons": "1.2.0",
         "@feathersjs/errors": "3.0.0",
@@ -83,9 +82,9 @@
       }
     },
     "@feathersjs/socket-commons": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@feathersjs/socket-commons/-/socket-commons-3.0.0.tgz",
-      "integrity": "sha512-t/i8PDUBx/FZj3osF2IewZ6HaYH9dGXE+ZGfQc5WuSz7nKqdaBTZuKyZdi8C7/rEaTsbHShtZm/kfrWNoVAB+w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/socket-commons/-/socket-commons-3.0.1.tgz",
+      "integrity": "sha512-/WgXC7tODg16uCGK5SKQYg3NvCdchJQyvBD1F0ljKWCee8N+Ep5TprN+i0/Ip4hAwWsQMQ7HIKBKdDvJ32aYyA==",
       "requires": {
         "@feathersjs/errors": "3.0.0",
         "debug": "3.1.0",
@@ -94,22 +93,22 @@
       }
     },
     "@feathersjs/socketio": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@feathersjs/socketio/-/socketio-3.0.0.tgz",
-      "integrity": "sha512-v8ztUUqUImzvDhW3qLfYXpkNDjVV0Sl2sLOdd6xhjnyQxp1gywDdpr09jcCegqdrhYzawg4TBDqW85+t4XGkuA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/socketio/-/socketio-3.0.1.tgz",
+      "integrity": "sha512-YZFpj52tu1QrO/n74CyeceCZ20dr3CIN6cGYHTbvl+As+aNY7yzQTvUVKBOrOfLUu/tuI4u1W+BzH+30+9ySSA==",
       "dev": true,
       "requires": {
-        "@feathersjs/socket-commons": "3.0.0",
+        "@feathersjs/socket-commons": "3.0.1",
         "debug": "3.1.0",
         "socket.io": "2.0.4"
       }
     },
     "@feathersjs/socketio-client": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@feathersjs/socketio-client/-/socketio-client-1.0.0.tgz",
-      "integrity": "sha512-L85LEMqZemqkFNcaxUetHKfYlBmA8RwEzoUrQ1OeEkkh+ndduDg9+je/J3bYJHV4SPgLLMFllgSwvdbrWOCBaA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/socketio-client/-/socketio-client-1.0.1.tgz",
+      "integrity": "sha512-RPJKdmdi5gMj4cqN/28Fl8U3x+JAFp95upJ1qSZ17+n0IzNkonoSRlyqzpo52ku9SvOJzFdWmfzlavSyjd0Agg==",
       "requires": {
-        "@feathersjs/socket-commons": "3.0.0"
+        "@feathersjs/socket-commons": "3.0.1"
       }
     },
     "abab": {
@@ -439,7 +438,8 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "dev": true
     },
     "asyncemit": {
       "version": "3.0.1",
@@ -1261,12 +1261,12 @@
       }
     },
     "browserify-zlib": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "0.2.9"
+        "pako": "1.0.6"
       }
     },
     "buffer": {
@@ -1313,9 +1313,9 @@
       "dev": true
     },
     "cacache": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.0.tgz",
-      "integrity": "sha512-s9h6I9NY3KcBjfuS28K6XNmrv/HNFSzlpVD6eYMXugZg3Y8jjI1lUzTeUMa0oKByCDtHfsIy5Ec7KgWRnC5gtg==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.1.tgz",
+      "integrity": "sha512-dRHYcs9LvG9cHgdPzjiI+/eS7e1xRhULrcyOx04RZQsszNJXU2SL9CyG60yLnge282Qq5nwTv+ieK2fH+WPZmA==",
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",
@@ -1432,7 +1432,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.2",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -1813,9 +1813,9 @@
       }
     },
     "crypto-browserify": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-      "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
         "browserify-cipher": "1.0.0",
@@ -1827,7 +1827,8 @@
         "inherits": "2.0.3",
         "pbkdf2": "3.0.14",
         "public-encrypt": "4.0.0",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.5",
+        "randomfill": "1.0.3"
       }
     },
     "cssom": {
@@ -2160,9 +2161,9 @@
       }
     },
     "engine.io": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.1.3.tgz",
-      "integrity": "sha1-euz3G/ijEPn6IUYZmcT8wDX4qHc=",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.1.4.tgz",
+      "integrity": "sha1-PQIRtwpVLOhB/8fahiezAamkFi4=",
       "dev": true,
       "requires": {
         "accepts": "1.3.3",
@@ -2171,7 +2172,7 @@
         "debug": "2.6.9",
         "engine.io-parser": "2.1.1",
         "uws": "0.14.5",
-        "ws": "2.3.1"
+        "ws": "3.3.1"
       },
       "dependencies": {
         "accepts": {
@@ -2192,29 +2193,13 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-          "dev": true
-        },
-        "ws": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
-          "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1",
-            "ultron": "1.1.0"
-          }
         }
       }
     },
     "engine.io-client": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.3.tgz",
-      "integrity": "sha1-1wXkiYXf6LVKmMn3cFK4sIJYvgU=",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.4.tgz",
+      "integrity": "sha1-T88TcLRxY70s6b4nM5ckMDUNTqE=",
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
@@ -2225,7 +2210,7 @@
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "2.3.1",
+        "ws": "3.3.1",
         "xmlhttprequest-ssl": "1.5.4",
         "yeast": "0.1.2"
       },
@@ -2237,22 +2222,6 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-          "dev": true
-        },
-        "ws": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
-          "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1",
-            "ultron": "1.1.0"
           }
         }
       }
@@ -2463,7 +2432,7 @@
         "debug": "2.6.9",
         "doctrine": "2.0.0",
         "escope": "3.6.0",
-        "espree": "3.5.1",
+        "espree": "3.5.2",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
@@ -2710,9 +2679,9 @@
       "dev": true
     },
     "espree": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
-      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
         "acorn": "5.2.1",
@@ -3269,14 +3238,14 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.7.0",
-        "node-pre-gyp": "0.6.36"
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -3434,7 +3403,6 @@
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1"
           }
@@ -3478,6 +3446,12 @@
         },
         "delegates": {
           "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3623,7 +3597,6 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1",
             "cryptiles": "2.0.5",
@@ -3795,11 +3768,13 @@
           "optional": true
         },
         "node-pre-gyp": {
-          "version": "0.6.36",
+          "version": "0.6.39",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
             "mkdirp": "0.5.1",
             "nopt": "4.0.1",
             "npmlog": "4.1.0",
@@ -4007,7 +3982,6 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -4616,9 +4590,9 @@
       }
     },
     "https-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-      "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
     "https-proxy-agent": {
@@ -5027,7 +5001,7 @@
       "integrity": "sha512-oFCwXvd65amgaPCzqrR+a2XjanS1MvpXN6l/MlMUTv6uiA1NOgGX+I0uyq8Lg3GDxsxPsaP1049krz3hIJ5+KA==",
       "dev": true,
       "requires": {
-        "async": "2.5.0",
+        "async": "2.6.0",
         "fileset": "2.0.3",
         "istanbul-lib-coverage": "1.1.1",
         "istanbul-lib-hook": "1.1.0",
@@ -5041,9 +5015,9 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
             "lodash": "4.17.4"
@@ -5661,7 +5635,7 @@
         "flush-write-stream": "1.0.2",
         "from2": "2.3.0",
         "parallel-transform": "1.1.0",
-        "pump": "1.0.2",
+        "pump": "1.0.3",
         "pumpify": "1.3.5",
         "stream-each": "1.2.2",
         "through2": "2.0.3"
@@ -5780,9 +5754,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
       "dev": true,
       "optional": true
     },
@@ -5820,21 +5794,21 @@
       }
     },
     "node-libs-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
-      "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+      "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "dev": true,
       "requires": {
         "assert": "1.4.1",
-        "browserify-zlib": "0.1.4",
+        "browserify-zlib": "0.2.0",
         "buffer": "4.9.1",
         "console-browserify": "1.1.0",
         "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.11.1",
+        "crypto-browserify": "3.12.0",
         "domain-browser": "1.1.7",
         "events": "1.1.1",
-        "https-browserify": "0.0.1",
-        "os-browserify": "0.2.1",
+        "https-browserify": "1.0.0",
+        "os-browserify": "0.3.0",
         "path-browserify": "0.0.0",
         "process": "0.11.10",
         "punycode": "1.4.1",
@@ -5842,20 +5816,12 @@
         "readable-stream": "2.3.3",
         "stream-browserify": "2.0.1",
         "stream-http": "2.7.2",
-        "string_decoder": "0.10.31",
+        "string_decoder": "1.0.3",
         "timers-browserify": "2.0.4",
         "tty-browserify": "0.0.0",
         "url": "0.11.0",
         "util": "0.10.3",
         "vm-browserify": "0.0.4"
-      },
-      "dependencies": {
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
       }
     },
     "nopt": {
@@ -6022,9 +5988,9 @@
       }
     },
     "os-browserify": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
-      "integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
     "os-homedir": {
@@ -6072,9 +6038,9 @@
       }
     },
     "pako": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
       "dev": true
     },
     "parallel-transform": {
@@ -6105,7 +6071,7 @@
         "node-ipc": "9.1.1",
         "pluralize": "1.2.1",
         "supports-color": "3.2.3",
-        "worker-farm": "1.5.1"
+        "worker-farm": "1.5.2"
       },
       "dependencies": {
         "ajv": {
@@ -6503,9 +6469,9 @@
       }
     },
     "pump": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-      "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
       "dev": true,
       "requires": {
         "end-of-stream": "1.4.0",
@@ -6520,7 +6486,7 @@
       "requires": {
         "duplexify": "3.5.1",
         "inherits": "2.0.3",
-        "pump": "1.0.2"
+        "pump": "1.0.3"
       }
     },
     "punycode": {
@@ -6599,6 +6565,16 @@
       "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
       "dev": true,
       "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "randomfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
+      "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+      "dev": true,
+      "requires": {
+        "randombytes": "2.0.5",
         "safe-buffer": "5.1.1"
       }
     },
@@ -6964,7 +6940,8 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
     },
     "sauce-tunnel": {
       "version": "2.5.0",
@@ -7216,7 +7193,7 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "engine.io": "3.1.3",
+        "engine.io": "3.1.4",
         "socket.io-adapter": "1.1.1",
         "socket.io-client": "2.0.4",
         "socket.io-parser": "3.1.2"
@@ -7250,7 +7227,7 @@
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
         "debug": "2.6.9",
-        "engine.io-client": "3.1.3",
+        "engine.io-client": "3.1.4",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
@@ -7513,9 +7490,9 @@
       "dev": true
     },
     "superagent": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.0.tgz",
-      "integrity": "sha512-71XGWgtn70TNwgmgYa69dPOYg55aU9FCahjUNY03rOrKvaTCaU3b9MeZmqonmf9Od96SCxr3vGfEAnhM7dtxCw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.1.tgz",
+      "integrity": "sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==",
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
@@ -7775,19 +7752,19 @@
       "integrity": "sha512-3IJhab8Xq7s6XqoPiVFuDpijefJsIrzACT4ggDErSxJAsB9GLDyuWpN7vuX4Lslu/nzIRz2NyXNX/fRMOgqRFw==",
       "dev": true,
       "requires": {
-        "cacache": "10.0.0",
+        "cacache": "10.0.1",
         "find-cache-dir": "1.0.0",
         "schema-utils": "0.3.0",
         "source-map": "0.5.7",
-        "uglify-es": "3.1.6",
-        "webpack-sources": "1.0.1",
-        "worker-farm": "1.5.1"
+        "uglify-es": "3.1.9",
+        "webpack-sources": "1.0.2",
+        "worker-farm": "1.5.2"
       },
       "dependencies": {
         "uglify-es": {
-          "version": "3.1.6",
-          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.1.6.tgz",
-          "integrity": "sha512-7zyH8T4rT3/iLVzNI7Oa8hVQSlv280S8y2/a2EmvEObft3067rdUJJKjBspc70d0HUk1Og1V5Ny4UgZOlZ0hSg==",
+          "version": "3.1.9",
+          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.1.9.tgz",
+          "integrity": "sha512-wVSiJKHDgDDFmxTVVvnbAH6IpamAFHYDI+5JvwPdaqIMnk8kRTX2JKwq1Fx7gb2+Jj5Dus8kzvIpKkWOMNU51w==",
           "dev": true,
           "requires": {
             "commander": "2.11.0",
@@ -7807,7 +7784,8 @@
     "ultron": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
-      "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ="
+      "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ=",
+      "dev": true
     },
     "underscore.string": {
       "version": "3.2.3",
@@ -7961,15 +7939,15 @@
       "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
       "dev": true,
       "requires": {
-        "async": "2.5.0",
+        "async": "2.6.0",
         "chokidar": "1.7.0",
         "graceful-fs": "4.1.11"
       },
       "dependencies": {
         "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
             "lodash": "4.17.4"
@@ -7993,7 +7971,7 @@
         "acorn-dynamic-import": "2.0.2",
         "ajv": "5.3.0",
         "ajv-keywords": "2.1.1",
-        "async": "2.5.0",
+        "async": "2.6.0",
         "enhanced-resolve": "3.4.1",
         "escope": "3.6.0",
         "interpret": "1.0.4",
@@ -8003,13 +7981,13 @@
         "loader-utils": "1.1.0",
         "memory-fs": "0.4.1",
         "mkdirp": "0.5.1",
-        "node-libs-browser": "2.0.0",
+        "node-libs-browser": "2.1.0",
         "source-map": "0.5.7",
         "supports-color": "4.5.0",
         "tapable": "0.2.8",
         "uglifyjs-webpack-plugin": "0.4.6",
         "watchpack": "1.4.0",
-        "webpack-sources": "1.0.1",
+        "webpack-sources": "1.0.2",
         "yargs": "8.0.2"
       },
       "dependencies": {
@@ -8032,9 +8010,9 @@
           "dev": true
         },
         "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
             "lodash": "4.17.4"
@@ -8174,7 +8152,7 @@
           "requires": {
             "source-map": "0.5.7",
             "uglify-js": "2.8.29",
-            "webpack-sources": "1.0.1"
+            "webpack-sources": "1.0.2"
           }
         },
         "yargs": {
@@ -8210,13 +8188,21 @@
       }
     },
     "webpack-sources": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
-      "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.2.tgz",
+      "integrity": "sha512-Y7UddMCv6dGjy81nBv6nuQeFFIt5aalHm7uyDsAsW86nZwfOVPGRr3XMjEQLaT+WKo8rlzhC9qtbJvYKLtAwaw==",
       "dev": true,
       "requires": {
         "source-list-map": "2.0.0",
-        "source-map": "0.5.7"
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "whatwg-url": {
@@ -8263,9 +8249,9 @@
       "dev": true
     },
     "worker-farm": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.1.tgz",
-      "integrity": "sha512-T5NH6Wqsd8MwGD4AK8BBllUy6LmHaqjEOyo/YIUEegZui6/v5Bqde//3jwyE3PGiGYMmWi06exFBi5LNhhPFNw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz",
+      "integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
       "dev": true,
       "requires": {
         "errno": "0.1.4",
@@ -8298,9 +8284,10 @@
       }
     },
     "ws": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.2.0.tgz",
-      "integrity": "sha512-hTS3mkXm/j85jTQOIcwVz3yK3up9xHgPtgEhDBOH3G18LDOZmSAG1omJeXejLKJakx+okv8vS1sopgs7rw0kVw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.1.tgz",
+      "integrity": "sha512-8A/uRMnQy8KCQsmep1m7Bk+z/+LIkeF7w+TDMLtX1iZm5Hq9HsUDmgFGaW1ACW5Cj0b2Qo7wCvRhYN2ErUVp/A==",
+      "dev": true,
       "requires": {
         "async-limiter": "1.0.0",
         "safe-buffer": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -50,12 +50,12 @@
     "ignore": "jsdom"
   },
   "dependencies": {
-    "@feathersjs/feathers": "3.0.1",
+    "@feathersjs/authentication-client": "1.0.1",
     "@feathersjs/errors": "3.0.0",
-    "@feathersjs/authentication-client": "1.0.0",
-    "@feathersjs/primus-client": "1.0.0",
-    "@feathersjs/rest-client": "1.3.0",
-    "@feathersjs/socketio-client": "1.0.0"
+    "@feathersjs/feathers": "3.0.1",
+    "@feathersjs/primus-client": "1.0.1",
+    "@feathersjs/rest-client": "1.3.2",
+    "@feathersjs/socketio-client": "1.0.1"
   },
   "devDependencies": {
     "@feathersjs/commons": "^1.2.0",

--- a/primus.js
+++ b/primus.js
@@ -1,1 +1,1 @@
-module.exports = require('@feathersjs/primus-client');
+module.exports = require('./dist/primus');

--- a/rest.js
+++ b/rest.js
@@ -1,1 +1,1 @@
-module.exports = require('@feathersjs/rest-client');
+module.exports = require('./dist/rest');

--- a/socketio.js
+++ b/socketio.js
@@ -1,1 +1,1 @@
-module.exports = require('@feathersjs/socketio-client');
+module.exports = require('./dist/socketio');

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -1,0 +1,1 @@
+module.exports = require('@feathersjs/authentication-client');

--- a/src/core.js
+++ b/src/core.js
@@ -1,0 +1,1 @@
+module.exports = require('@feathersjs/feathers');

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,16 @@
+const feathers = require('@feathersjs/feathers');
+const errors = require('@feathersjs/errors');
+const authentication = require('@feathersjs/authentication-client');
+const rest = require('@feathersjs/rest-client');
+const socketio = require('@feathersjs/socketio-client');
+const primus = require('@feathersjs/primus-client');
+
+Object.assign(feathers, {
+  errors,
+  authentication,
+  socketio,
+  primus,
+  rest
+});
+
+module.exports = feathers;

--- a/src/primus.js
+++ b/src/primus.js
@@ -1,0 +1,1 @@
+module.exports = require('@feathersjs/primus-client');

--- a/src/rest.js
+++ b/src/rest.js
@@ -1,0 +1,1 @@
+module.exports = require('@feathersjs/rest-client');

--- a/src/socketio.js
+++ b/src/socketio.js
@@ -1,0 +1,1 @@
+module.exports = require('@feathersjs/socketio-client');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 function createConfig (name, isProduction = false) {
   const output = name === 'index' ? 'feathers' : name;
   const commons = {
-    entry: `./${name}.js`,
+    entry: `./src/${name}.js`,
     output: {
       library: 'feathers',
       libraryTarget: 'umd',


### PR DESCRIPTION
This will link things like importing `@feathersjs/client` or `@feathersjs/client/rest` directly to the built packages instead of pulling in the non-transpiled versions.
This will make it easier to use with most module loaders since they don't transpile dependencies in `node_modules` by default which is currently unfortunately almost all of them.